### PR TITLE
Ветка prool-test-crypt синхронизируется с веткой master

### DIFF
--- a/admin/acinclude.m4.in
+++ b/admin/acinclude.m4.in
@@ -128,13 +128,13 @@ AC_DEFUN([AC_CREATE_FILE],
 
 AC_DEFUN([AC_CHECK_OPTIMIZATION],
 [
-  AC_ARG_ENABLE(optimization,[  --disable-optimization   do not create optimized code [default=no]],
+  AC_ARG_ENABLE(optimization,[  --disable-optimization   do not create optimized code [default=yes]],
   [
    if test $enableval = "no"; dnl
      then ac_use_optimization_code="no"
      else ac_use_optimization_code="yes"
    fi
-  ], [ac_use_optimization_code="yes"])
+  ], [ac_use_optimization_code="no"])
 
   if test "$ac_use_optimization_code" = "yes"; then
 dnl    AC_MSG_CHECKING([whether $CXX accepts -mpentium])
@@ -153,8 +153,8 @@ dnl    rm -fr conftest*
     CXXFLAGS="$CXXFLAGS -fexpensive-optimizations -O3 -g"
     CFLAGS="$CFLAGS  -fexpensive-optimizations -O3 -g"
   else
-    CXXFLAGS="$CXXFLAGS -O2 -g"
-    CFLAGS="$CFLAGS  -O2 -g"
+    CXXFLAGS="$CXXFLAGS -Og -g"
+    CFLAGS="$CFLAGS  -Og -g"
   fi
 ])
 
@@ -162,8 +162,8 @@ AC_DEFUN([AC_CHECK_BITNESS],
 [
     case $host_cpu in
     *64)
-        CXXFLAGS="$CXXFLAGS -m32 -Wl,-melf_i386"
-        CFLAGS="$CFLAGS -m32 -Wl,-melf_i386"
+        CXXFLAGS="$CXXFLAGS -m32 -Wl,-melf_i386 --std=c++14 -Wno-narrowing"
+        CFLAGS="$CFLAGS -m32 -Wl,-melf_i386 --std=c++14 -Wno-narrowing"
         LDFLAGS="$LDFLAGS -Wl,-melf_i386"
         ;;
     esac


### PR DESCRIPTION
Так надо, потому что ветка prool-test-crypt будет крутиться у меня на ПрульГранях (mud.kharkov.org 6000) в качестве тестового и экспериментального мада с отключенным криптованием (потому что оно глючит на моей VDS) и некоторым другими экспериментальными изменениями (например, с созданием файла для статистики munin).

И большинство измненений из ветки prool-test-crypt никому не нужны, так как это всякие финтифлюшки 